### PR TITLE
Handle model and temperature in template extraction without duplication

### DIFF
--- a/langextract_extensions/template_builder.py
+++ b/langextract_extensions/template_builder.py
@@ -476,12 +476,15 @@ def extract_with_template(
         document = data.Document(text=document)
     
     # Extract using template
+    model_id = kwargs.pop('model_id', template.preferred_model)
+    temperature = kwargs.pop('temperature', template.temperature)
+
     result = extract(
         text_or_documents=document,
         prompt_description=template.generate_prompt(),
         examples=template.generate_examples(),
-        model_id=kwargs.get('model_id', template.preferred_model),
-        temperature=kwargs.get('temperature', template.temperature),
+        model_id=model_id,
+        temperature=temperature,
         **kwargs
     )
     

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -6,6 +6,7 @@ import os
 import pytest
 from pathlib import Path
 from datetime import datetime
+from unittest.mock import patch
 
 from langextract import data
 from langextract_extensions.templates import (
@@ -373,6 +374,34 @@ class TestExtractWithTemplate:
         assert result is not None
         assert isinstance(result, data.AnnotatedDocument)
         assert len(result.extractions) > 0
+
+    def test_extract_with_template_with_model_and_temperature(self, temp_dir, sample_legal_text):
+        """Ensure model_id and temperature can be provided without conflict."""
+        template = ExtractionTemplate(
+            template_id="legal_test",
+            name="Legal Test",
+            description="Test legal extraction",
+            document_type=DocumentType.LEGAL_JUDGMENT,
+            fields=[
+                ExtractionField("plaintiff", "organization", "Plaintiff"),
+                ExtractionField("defendant", "person", "Defendant")
+            ]
+        )
+
+        with patch("langextract_extensions.template_builder.extract") as mock_extract:
+            mock_extract.return_value = data.AnnotatedDocument(text=sample_legal_text, extractions=[])
+
+            result = extract_with_template(
+                document=sample_legal_text,
+                template=template,
+                model_id="gemini-2.5-pro",
+                temperature=0.5,
+            )
+
+            assert result is not None
+            call_args = mock_extract.call_args
+            assert call_args.kwargs["model_id"] == "gemini-2.5-pro"
+            assert call_args.kwargs["temperature"] == 0.5
     
     @pytest.mark.skipif(not os.environ.get("GOOGLE_API_KEY"), 
                         reason="Requires GOOGLE_API_KEY")


### PR DESCRIPTION
## Summary
- Ensure `extract_with_template` removes `model_id` and `temperature` from `kwargs` before calling `extract`
- Added regression test verifying custom `model_id` and `temperature` are forwarded correctly

## Testing
- ⚠️ `pytest -q` (fails: ImportError: cannot import name 'ExtractionTemplate' from 'langextract_extensions')
- ✅ `pytest tests/test_templates.py::TestExtractWithTemplate::test_extract_with_template_with_model_and_temperature -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f8382e6c8321bbe19646063efef0