### PR TITLE
Handle custom output filenames more robustly

### DIFF
--- a/langextract_extensions/cli.py
+++ b/langextract_extensions/cli.py
@@ -220,13 +220,15 @@ def extract(input, output, format, model, prompt, template, examples, api_key, t
     try:
         if format == 'html':
             # Save JSONL first
-            jsonl_path = output.replace('.html', '.jsonl')
+            root, _ = os.path.splitext(output)
+            jsonl_path = root + '.jsonl'
             lx.io.save_annotated_documents([result], output_name=jsonl_path)
             # Generate HTML
             html = lx.visualize(jsonl_path)
-            with open(output, 'w') as f:
+            html_path = root + '.html'
+            with open(html_path, 'w') as f:
                 f.write(html)
-            click.echo(f"✓ Created HTML visualization: {output}")
+            click.echo(f"✓ Created HTML visualization: {html_path}")
             
         elif format == 'jsonl':
             lx.io.save_annotated_documents([result], output_name=output)
@@ -239,11 +241,13 @@ def extract(input, output, format, model, prompt, template, examples, api_key, t
             
         elif format == 'gif':
             # Save JSONL first
-            jsonl_path = output.replace('.gif', '.jsonl')
+            root, _ = os.path.splitext(output)
+            jsonl_path = root + '.jsonl'
             lx.io.save_annotated_documents([result], output_name=jsonl_path)
             # Create GIF
-            create_simple_gif(jsonl_path, output)
-            click.echo(f"✓ Created GIF: {output}")
+            gif_path = root + '.gif'
+            create_simple_gif(jsonl_path, gif_path)
+            click.echo(f"✓ Created GIF: {gif_path}")
             
     except Exception as e:
         click.echo(f"Error saving output: {e}", err=True)
@@ -353,16 +357,20 @@ def multipass(input, strategy, passes, output, model, debug):
         )
         
         # Save results
-        if output.endswith('.html'):
-            jsonl_path = output.replace('.html', '.jsonl')
+        root, ext = os.path.splitext(output)
+        if ext == '.html' or ext == '':
+            jsonl_path = root + '.jsonl'
             lx.io.save_annotated_documents([result], output_name=jsonl_path)
             html = lx.visualize(jsonl_path)
-            with open(output, 'w') as f:
+            html_path = root + '.html'
+            with open(html_path, 'w') as f:
                 f.write(html)
+            output_path = html_path
         else:
             lx.io.save_annotated_documents([result], output_name=output)
-        
-        click.echo(f"✓ Saved results: {output}")
+            output_path = output
+
+        click.echo(f"✓ Saved results: {output_path}")
         click.echo(f"Total extractions: {len(result.extractions)}")
         
     except Exception as e:

--- a/tests/test_cli_custom_filename.py
+++ b/tests/test_cli_custom_filename.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from click.testing import CliRunner
+from unittest.mock import MagicMock
+
+from langextract import data
+
+
+def _setup_cli(monkeypatch):
+    import importlib
+    import langextract_extensions.templates as templates
+    if not hasattr(templates, "list_builtin_templates"):
+        templates.list_builtin_templates = lambda: []
+    cli_module = importlib.import_module("langextract_extensions.cli")
+    mock_result = data.AnnotatedDocument(text="result", extractions=[], document_id="doc1")
+    monkeypatch.setattr("langextract.extract", MagicMock(return_value=mock_result))
+    monkeypatch.setattr(cli_module.lx, "visualize", lambda path: "<html></html>")
+    monkeypatch.setattr(cli_module.lx.io, "save_annotated_documents", lambda docs, output_name: Path(output_name).write_text("data"))
+    return cli_module
+
+
+def test_extract_html_custom_filename(monkeypatch):
+    cli_module = _setup_cli(monkeypatch)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        text_path = Path("input.txt")
+        text_path.write_text("sample")
+        result = runner.invoke(
+            cli_module.cli,
+            [
+                "extract",
+                "-i",
+                str(text_path),
+                "-p",
+                "Find text",
+                "-o",
+                "custom",
+                "-f",
+                "html",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("custom.html").exists()
+        assert Path("custom.jsonl").exists()
+
+
+def test_extract_gif_custom_filename(monkeypatch):
+    cli_module = _setup_cli(monkeypatch)
+    monkeypatch.setattr(cli_module, "create_simple_gif", lambda jsonl, gif: Path(gif).write_bytes(b"GIF89a"))
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        text_path = Path("input.txt")
+        text_path.write_text("sample")
+        result = runner.invoke(
+            cli_module.cli,
+            [
+                "extract",
+                "-i",
+                str(text_path),
+                "-p",
+                "Find text",
+                "-o",
+                "anim",
+                "-f",
+                "gif",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("anim.gif").exists()
+        assert Path("anim.jsonl").exists()


### PR DESCRIPTION
## Summary
- derive output filenames using `os.path.splitext` for HTML, GIF, and multipass saves
- add CLI tests for custom output filenames without extensions

## Testing
- `pytest`
- `pytest tests/test_cli_custom_filename.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ff181c68832181d548c0962f2000