### PR TITLE
Pop model config kwargs in extract_with_template

### DIFF
--- a/langextract_extensions/template_builder.py
+++ b/langextract_extensions/template_builder.py
@@ -476,8 +476,8 @@ def extract_with_template(
         document = data.Document(text=document)
     
     # Extract using template
-    model_id = kwargs.pop('model_id', template.preferred_model)
-    temperature = kwargs.pop('temperature', template.temperature)
+    model_id = kwargs.pop('model_id', None) or template.preferred_model
+    temperature = kwargs.pop('temperature', None) or template.temperature
 
     result = extract(
         text_or_documents=document,

--- a/tests/test_template_builder_regression.py
+++ b/tests/test_template_builder_regression.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from langextract import data
+from langextract_extensions.template_builder import extract_with_template
+from langextract_extensions.templates import (
+    ExtractionTemplate,
+    ExtractionField,
+    DocumentType,
+)
+
+
+def test_extract_with_template_allows_model_and_temperature(sample_legal_text):
+    """Ensure model_id and temperature kwargs are forwarded correctly."""
+    template = ExtractionTemplate(
+        template_id="legal_test",
+        name="Legal Test",
+        description="Test legal extraction",
+        document_type=DocumentType.LEGAL_JUDGMENT,
+        fields=[
+            ExtractionField("plaintiff", "organization", "Plaintiff"),
+            ExtractionField("defendant", "person", "Defendant"),
+        ],
+    )
+
+    with patch("langextract_extensions.template_builder.extract") as mock_extract:
+        mock_extract.return_value = data.AnnotatedDocument(
+            text=sample_legal_text, extractions=[]
+        )
+
+        result = extract_with_template(
+            document=sample_legal_text,
+            template=template,
+            model_id="gemini-2.5-pro",
+            temperature=0.5,
+        )
+
+        assert result is not None
+        call_args = mock_extract.call_args
+        assert call_args.kwargs["model_id"] == "gemini-2.5-pro"
+        assert call_args.kwargs["temperature"] == 0.5


### PR DESCRIPTION
## Summary
- Ensure `extract_with_template` pops `model_id` and `temperature` kwargs with fallback to template defaults
- Add regression test verifying custom `model_id` and `temperature` are forwarded correctly

## Testing
- `pytest tests/test_template_builder_regression.py -q`
- `pytest -q` *(fails: ImportError and numerous other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c570b3429883218ad9a440d13f16e1