### PR TITLE
Add helper to list builtin templates

### DIFF
--- a/langextract_extensions/templates.py
+++ b/langextract_extensions/templates.py
@@ -758,10 +758,15 @@ BUILTIN_TEMPLATES = {
 }
 
 
+def list_builtin_templates() -> List[str]:
+    """Return canonical identifiers for the built-in templates."""
+    return list(BUILTIN_TEMPLATES.keys())
+
+
 def get_builtin_template(template_type: str) -> Optional[ExtractionTemplate]:
     """
     Get a built-in template by type.
-    
+
     Args:
         template_type: Type of template (e.g., 'legal_judgment', 'invoice')
         
@@ -777,6 +782,7 @@ __all__ = [
     'ExtractionField',
     'ExtractionTemplate',
     'TemplateManager',
+    'list_builtin_templates',
     'get_builtin_template',
     'get_legal_judgment_template',
     'get_invoice_template',

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -6,9 +6,6 @@ import importlib
 
 
 def test_batch_examples_influence(monkeypatch, sample_examples):
-    import langextract_extensions.templates as templates
-    if not hasattr(templates, "list_builtin_templates"):
-        templates.list_builtin_templates = lambda: []
     cli_module = importlib.import_module("langextract_extensions.cli")
 
     captured = {}

--- a/tests/test_cli_custom_filename.py
+++ b/tests/test_cli_custom_filename.py
@@ -1,15 +1,12 @@
 from pathlib import Path
-from click.testing import CliRunner
 from unittest.mock import MagicMock
 
+from click.testing import CliRunner
 from langextract import data
 
 
 def _setup_cli(monkeypatch):
     import importlib
-    import langextract_extensions.templates as templates
-    if not hasattr(templates, "list_builtin_templates"):
-        templates.list_builtin_templates = lambda: []
     cli_module = importlib.import_module("langextract_extensions.cli")
     mock_result = data.AnnotatedDocument(text="result", extractions=[], document_id="doc1")
     monkeypatch.setattr("langextract.extract", MagicMock(return_value=mock_result))

--- a/tests/test_cli_pdf.py
+++ b/tests/test_cli_pdf.py
@@ -8,9 +8,6 @@ from langextract import data
 
 def test_extract_pdf_local(monkeypatch):
     import importlib
-    import langextract_extensions.templates as templates
-    if not hasattr(templates, "list_builtin_templates"):
-        templates.list_builtin_templates = lambda: []
     cli_module = importlib.import_module("langextract_extensions.cli")
 
     mock_result = data.AnnotatedDocument(text="result", extractions=[], document_id="doc1")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -11,11 +11,23 @@ from unittest.mock import patch
 from langextract import data
 from langextract_extensions.templates import (
     DocumentType, ExtractionField, ExtractionTemplate,
-    TemplateManager, get_builtin_template
+    TemplateManager, get_builtin_template, list_builtin_templates
 )
 from langextract_extensions.template_builder import (
     TemplateBuilder, extract_with_template
 )
+
+
+class TestBuiltinTemplates:
+    """Tests for built-in template helpers."""
+
+    def test_list_builtin_templates_matches_registry(self):
+        import langextract_extensions.templates as template_module
+
+        builtin_ids = list_builtin_templates()
+
+        assert isinstance(builtin_ids, list)
+        assert builtin_ids == list(template_module.BUILTIN_TEMPLATES.keys())
 
 
 class TestExtractionField:


### PR DESCRIPTION
## Summary
- add a list_builtin_templates helper that returns the registered builtin template identifiers and export it from the templates module
- update CLI-oriented tests to rely on the new helper instead of monkey-patching and fix their imports
- extend the template test suite with coverage for the builtin template registry helper

## Testing
- pytest tests/test_cli_pdf.py tests/test_cli_batch.py tests/test_cli_custom_filename.py tests/test_templates.py *(fails: ModuleNotFoundError: No module named 'langextract')*

------
https://chatgpt.com/codex/tasks/task_e_68d15e7aaca083218c9ba9a72744a310