### PR TITLE
Revise annotation models and add structured annotation tests

### DIFF
--- a/langextract_extensions/annotation.py
+++ b/langextract_extensions/annotation.py
@@ -1,235 +1,324 @@
-"""
-Annotation module for quality scoring and verification.
-
-This module provides functionality to:
-- Add quality scores and confidence metrics to extractions
-- Verify extractions against rules and external data
-- Create audit trails with timestamps and metadata
-- Provide rich annotations for downstream processing
-"""
+"""Utilities for annotating LangExtract results."""
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Dict, Any, Optional, Set, Tuple
 from enum import Enum
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
 import re
-import json
 
 from langextract import data
 
 
-class AnnotationType(Enum):
+class AnnotationType(str, Enum):
     """Types of annotations that can be added to extractions."""
-    QUALITY = "quality"
+
+    QUALITY_SCORE = "quality_score"
     VERIFICATION = "verification"
-    WARNING = "warning"
-    NOTE = "note"
-    RELATIONSHIP = "relationship"
     CORRECTION = "correction"
+    NOTE = "note"
+    WARNING = "warning"
+    ERROR = "error"
+    # Backwards compatible / extended types
+    QUALITY = "quality"
+    RELATIONSHIP = "relationship"
     METADATA = "metadata"
 
 
-class ConfidenceLevel(Enum):
+class ConfidenceLevel(str, Enum):
     """Confidence levels for annotations."""
-    VERY_HIGH = 0.9
-    HIGH = 0.75
-    MEDIUM = 0.5
-    LOW = 0.25
-    VERY_LOW = 0.1
+
+    VERY_HIGH = "very_high"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    VERY_LOW = "very_low"
+    UNCERTAIN = "uncertain"
+
+    @property
+    def score(self) -> float:
+        """Return the numeric representation for the confidence level."""
+
+        scores = {
+            ConfidenceLevel.VERY_HIGH: 0.95,
+            ConfidenceLevel.HIGH: 0.8,
+            ConfidenceLevel.MEDIUM: 0.6,
+            ConfidenceLevel.LOW: 0.35,
+            ConfidenceLevel.VERY_LOW: 0.1,
+            ConfidenceLevel.UNCERTAIN: 0.5,
+        }
+        return scores[self]
 
 
 @dataclass
 class Annotation:
     """Represents an annotation on extracted data."""
-    annotation_id: str
-    extraction_id: str
+
     annotation_type: AnnotationType
-    content: str
-    confidence: float = 0.5
+    content: Union[Dict[str, Any], List[Any], str] = field(default_factory=dict)
+    annotation_id: Optional[str] = None
+    extraction_id: Optional[str] = None
+    confidence: Optional[Union[float, ConfidenceLevel]] = None
     timestamp: Optional[datetime] = None
     author: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
-    
+
+    def __post_init__(self) -> None:
+        """Normalise field types and defaults."""
+
+        if isinstance(self.annotation_type, str):
+            self.annotation_type = AnnotationType(self.annotation_type)
+
+        if self.content is None:
+            self.content = {}
+
+        if isinstance(self.confidence, str):
+            try:
+                self.confidence = ConfidenceLevel(self.confidence)
+            except ValueError:
+                # Leave custom string confidences untouched
+                pass
+
     def to_dict(self) -> Dict[str, Any]:
-        """Convert annotation to dictionary."""
+        """Convert annotation to a serialisable dictionary."""
+
+        confidence: Optional[Union[str, float]]
+        if isinstance(self.confidence, ConfidenceLevel):
+            confidence = self.confidence.value
+        else:
+            confidence = self.confidence
+
         return {
-            'annotation_id': self.annotation_id,
-            'extraction_id': self.extraction_id,
-            'type': self.annotation_type.value,
-            'content': self.content,
-            'confidence': self.confidence,
-            'timestamp': self.timestamp.isoformat() if self.timestamp else None,
-            'author': self.author,
-            'metadata': self.metadata
+            "annotation_id": self.annotation_id,
+            "extraction_id": self.extraction_id,
+            "type": self.annotation_type.value,
+            "content": self.content,
+            "confidence": confidence,
+            "timestamp": self.timestamp.isoformat() if self.timestamp else None,
+            "author": self.author,
+            "metadata": self.metadata,
         }
 
 
 class QualityScorer:
-    """Scores extraction quality based on various factors."""
-    
-    def __init__(self):
-        """Initialize the quality scorer."""
+    """Scores extraction quality based on various heuristics."""
+
+    def __init__(self) -> None:
         self.scoring_factors = {
-            'alignment': 0.3,      # Weight for alignment quality
-            'length': 0.2,         # Weight for appropriate length
-            'pattern': 0.2,        # Weight for pattern matching
-            'consistency': 0.3     # Weight for consistency
+            "alignment": 0.35,
+            "length": 0.15,
+            "pattern": 0.2,
+            "consistency": 0.2,
+            "context": 0.1,
         }
-    
+
     def score_extraction(
         self,
         extraction: data.Extraction,
         text: str,
-        all_extractions: Optional[List[data.Extraction]] = None
+        all_extractions: Optional[List[data.Extraction]] = None,
     ) -> float:
-        """
-        Calculate quality score for an extraction.
-        
-        Args:
-            extraction: The extraction to score
-            text: Original document text
-            all_extractions: All extractions for consistency checking
-            
-        Returns:
-            Quality score between 0 and 1
-        """
-        scores = {}
-        
-        # Score alignment quality
-        scores['alignment'] = self._score_alignment(extraction)
-        
-        # Score length appropriateness
-        scores['length'] = self._score_length(extraction)
-        
-        # Score pattern matching
-        scores['pattern'] = self._score_pattern(extraction)
-        
-        # Score consistency with other extractions
-        if all_extractions:
-            scores['consistency'] = self._score_consistency(extraction, all_extractions)
-        else:
-            scores['consistency'] = 0.5  # Neutral if no comparison possible
-        
-        # Calculate weighted score
-        total_score = sum(
-            scores[factor] * weight 
+        """Calculate a quality score for an extraction."""
+
+        factor_scores = self._compute_factor_scores(extraction, text, all_extractions)
+        total_score = self._aggregate_factor_scores(factor_scores)
+        total_score = self._apply_penalties(extraction, text, total_score)
+        return min(max(total_score, 0.0), 1.0)
+
+    def score_batch(
+        self, extractions: Iterable[data.Extraction], text: str
+    ) -> List[float]:
+        """Score multiple extractions against the same document text."""
+
+        extraction_list = list(extractions)
+        return [
+            self.score_extraction(extraction, text, extraction_list)
+            for extraction in extraction_list
+        ]
+
+    def _compute_factor_scores(
+        self,
+        extraction: data.Extraction,
+        text: str,
+        all_extractions: Optional[List[data.Extraction]] = None,
+    ) -> Dict[str, float]:
+        scores: Dict[str, float] = {}
+        scores["alignment"] = self._score_alignment(extraction, text)
+        scores["length"] = self._score_length(extraction)
+        scores["pattern"] = self._score_pattern(extraction)
+        scores["consistency"] = (
+            self._score_consistency(extraction, all_extractions)
+            if all_extractions
+            else 0.5
+        )
+        scores["context"] = self._score_context(extraction, text)
+        return scores
+
+    def _aggregate_factor_scores(self, factor_scores: Dict[str, float]) -> float:
+        return sum(
+            factor_scores.get(factor, 0.5) * weight
             for factor, weight in self.scoring_factors.items()
         )
-        
-        return min(max(total_score, 0.0), 1.0)
-    
-    def _score_alignment(self, extraction: data.Extraction) -> float:
-        """Score based on alignment status."""
-        if not hasattr(extraction, 'alignment_status'):
-            return 0.5
-        
-        status_scores = {
-            'MATCH_EXACT': 1.0,
-            'MATCH_FUZZY': 0.7,
-            'MATCH_LESSER': 0.4,
-            'NO_MATCH': 0.1
-        }
-        
-        return status_scores.get(extraction.alignment_status, 0.5)
-    
-    def _score_length(self, extraction: data.Extraction) -> float:
-        """Score based on extraction length appropriateness."""
-        text_length = len(extraction.extraction_text)
-        
-        # Penalize very short or very long extractions
-        if text_length < 2:
-            return 0.2
-        elif text_length < 5:
-            return 0.6
-        elif text_length < 100:
-            return 1.0
-        elif text_length < 500:
-            return 0.8
+
+    def _apply_penalties(
+        self, extraction: data.Extraction, text: str, score: float
+    ) -> float:
+        text_value = getattr(extraction, "extraction_text", "") or ""
+        if text_value and text:
+            if text_value not in text:
+                score *= 0.6
         else:
-            return 0.4
-    
+            score *= 0.5
+
+        char_interval = getattr(extraction, "char_interval", None)
+        if not char_interval:
+            score *= 0.7
+
+        return score
+
+    def _score_alignment(self, extraction: data.Extraction, text: str) -> float:
+        score = 0.5
+
+        if hasattr(extraction, "alignment_status"):
+            status_scores = {
+                "MATCH_EXACT": 0.98,
+                "MATCH_FUZZY": 0.75,
+                "MATCH_LESSER": 0.45,
+                "NO_MATCH": 0.1,
+            }
+            score = status_scores.get(getattr(extraction, "alignment_status"), score)
+
+        char_interval = getattr(extraction, "char_interval", None)
+        if char_interval:
+            start = getattr(char_interval, "start", getattr(char_interval, "start_pos", None))
+            end = getattr(char_interval, "end", getattr(char_interval, "end_pos", None))
+            text_length = len(text) if text else 0
+            if (
+                isinstance(start, int)
+                and isinstance(end, int)
+                and 0 <= start < end <= text_length
+            ):
+                snippet = text[start:end]
+                extracted = (extraction.extraction_text or "").strip()
+                snippet_stripped = snippet.strip()
+                if extracted and snippet_stripped:
+                    if snippet_stripped == extracted:
+                        score = max(score, 0.98)
+                    elif extracted in snippet:
+                        score = max(score, 0.85)
+                    else:
+                        score = max(score, 0.65)
+                else:
+                    score = max(score, 0.6)
+            else:
+                score = min(score, 0.3)
+        else:
+            if extraction.extraction_text and text and extraction.extraction_text in text:
+                score = max(score, 0.6)
+            else:
+                score = min(score, 0.25)
+
+        return max(0.0, min(score, 1.0))
+
+    def _score_length(self, extraction: data.Extraction) -> float:
+        text_length = len(extraction.extraction_text or "")
+
+        if text_length < 2:
+            return 0.15
+        if text_length < 5:
+            return 0.6
+        if text_length < 100:
+            return 1.0
+        if text_length < 500:
+            return 0.8
+        return 0.4
+
     def _score_pattern(self, extraction: data.Extraction) -> float:
-        """Score based on pattern matching for extraction class."""
-        text = extraction.extraction_text
-        extraction_class = extraction.extraction_class
-        
+        text_value = extraction.extraction_text or ""
+        extraction_class = getattr(extraction, "extraction_class", None)
+
         if not extraction_class:
             return 0.5
-        
-        score = 0.5  # Base score
-        
-        # Check patterns based on class
-        if extraction_class == 'date':
-            # Check for date patterns
+
+        score = 0.5
+
+        if extraction_class == "date":
             date_patterns = [
-                r'\d{1,2}[/-]\d{1,2}[/-]\d{2,4}',
-                r'\d{4}[/-]\d{1,2}[/-]\d{1,2}',
-                r'(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*\s+\d{1,2},?\s+\d{4}',
+                r"\\d{1,2}[/-]\\d{1,2}[/-]\\d{2,4}",
+                r"\\d{4}[/-]\\d{1,2}[/-]\\d{1,2}",
+                r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\w*\\s+\\d{1,2},?\\s+\\d{4}",
             ]
-            if any(re.search(p, text) for p in date_patterns):
+            if any(re.search(p, text_value) for p in date_patterns):
                 score = 0.9
-        
-        elif extraction_class == 'email':
-            if re.match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', text):
+        elif extraction_class == "email":
+            if re.match(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", text_value):
                 score = 1.0
-        
-        elif extraction_class == 'phone':
-            phone_pattern = r'[\d\s\-\(\)\.]+\d'
-            if re.match(phone_pattern, text) and 7 <= len(re.sub(r'\D', '', text)) <= 15:
+        elif extraction_class == "phone":
+            phone_pattern = r"[\\d\\s\\-\(\)\.]+\\d"
+            if re.match(phone_pattern, text_value) and 7 <= len(re.sub(r"\\D", "", text_value)) <= 15:
                 score = 0.9
-        
-        elif extraction_class == 'amount' or extraction_class == 'money':
-            # Check for currency patterns
-            if re.search(r'[$€£¥]\s*[\d,]+\.?\d*', text) or re.search(r'[\d,]+\.?\d*\s*(dollars?|euros?|pounds?)', text.lower()):
+        elif extraction_class in {"amount", "money"}:
+            if re.search(r"[$€£¥]\\s*[\\d,]+\\.?\\d*", text_value) or re.search(
+                r"[\\d,]+\\.?\\d*\\s*(dollars?|euros?|pounds?)",
+                text_value.lower(),
+            ):
                 score = 0.9
-        
-        elif extraction_class == 'person' or extraction_class == 'name':
-            # Check for name patterns (capitalized words)
-            if re.match(r'^[A-Z][a-z]+(\s+[A-Z][a-z]+)*$', text):
+        elif extraction_class in {"person", "name"}:
+            if re.match(r"^[A-Z][a-z]+(\\s+[A-Z][a-z]+)*$", text_value):
                 score = 0.8
-        
+
         return score
-    
-    def _score_consistency(self, extraction: data.Extraction, all_extractions: List[data.Extraction]) -> float:
-        """Score based on consistency with other similar extractions."""
+
+    def _score_consistency(
+        self, extraction: data.Extraction, all_extractions: Optional[List[data.Extraction]]
+    ) -> float:
+        if not all_extractions:
+            return 0.5
+
         similar_extractions = [
-            e for e in all_extractions 
-            if e.extraction_class == extraction.extraction_class and e != extraction
+            e
+            for e in all_extractions
+            if e is not extraction and getattr(e, "extraction_class", None) == extraction.extraction_class
         ]
-        
+
         if not similar_extractions:
-            return 0.5  # No comparison possible
-        
-        # Check for consistent formatting
+            return 0.5
+
         consistency_score = 0.5
-        
-        if extraction.extraction_class in ['date', 'amount', 'phone']:
-            # Check if format is consistent with others
-            formats_match = 0
-            for other in similar_extractions:
-                if self._formats_similar(extraction.extraction_text, other.extraction_text):
-                    formats_match += 1
-            
-            if similar_extractions:
-                consistency_score = formats_match / len(similar_extractions)
-        
+
+        if extraction.extraction_class in ["date", "amount", "phone"]:
+            matches = sum(
+                1
+                for other in similar_extractions
+                if self._formats_similar(extraction.extraction_text, other.extraction_text)
+            )
+            consistency_score = matches / len(similar_extractions)
+
         return consistency_score
-    
+
     def _formats_similar(self, text1: str, text2: str) -> bool:
-        """Check if two texts have similar formatting."""
-        # Simple check: similar length and character types
+        if text1 is None or text2 is None:
+            return False
+
         if abs(len(text1) - len(text2)) > 5:
             return False
-        
-        # Check character type pattern
-        pattern1 = ''.join('D' if c.isdigit() else 'A' if c.isalpha() else 'S' for c in text1)
-        pattern2 = ''.join('D' if c.isdigit() else 'A' if c.isalpha() else 'S' for c in text2)
-        
-        # Calculate similarity
+
+        pattern1 = "".join("D" if c.isdigit() else "A" if c.isalpha() else "S" for c in text1)
+        pattern2 = "".join("D" if c.isdigit() else "A" if c.isalpha() else "S" for c in text2)
+
         matches = sum(1 for a, b in zip(pattern1, pattern2) if a == b)
         similarity = matches / max(len(pattern1), len(pattern2))
-        
         return similarity > 0.7
+
+    def _score_context(self, extraction: data.Extraction, text: str) -> float:
+        if not text or not extraction.extraction_text:
+            return 0.5
+
+        lowered_text = text.lower()
+        lowered_value = extraction.extraction_text.lower()
+        if lowered_value in lowered_text:
+            return 0.8
+        return 0.4
 
 
 class ExtractionVerifier:
@@ -247,17 +336,61 @@ class ExtractionVerifier:
             self._verify_date_range,
             self._verify_date_format
         ]
-        
+
         # Amount validation
         self.verification_rules['amount'] = [
             self._verify_amount_range,
             self._verify_amount_format
         ]
-        
+
         # Email validation
         self.verification_rules['email'] = [
             self._verify_email_format
         ]
+
+    def add_rule(
+        self,
+        extraction_class: str,
+        rule: Callable[..., Union[bool, Tuple[bool, str], Tuple[bool, str, float]]],
+        failure_message: Optional[str] = None,
+        confidence: float = 0.8,
+    ) -> None:
+        """Register a custom verification rule for an extraction class."""
+
+        if extraction_class not in self.verification_rules:
+            self.verification_rules[extraction_class] = []
+
+        def wrapped(
+            extraction: data.Extraction,
+            external_data: Optional[Dict[str, Any]] = None
+        ) -> Tuple[bool, str, float]:
+            try:
+                result = rule(extraction, external_data)
+            except TypeError:
+                try:
+                    result = rule(extraction.extraction_text, external_data)
+                except TypeError:
+                    result = rule(extraction.extraction_text)
+
+            if isinstance(result, tuple):
+                if len(result) == 3:
+                    return bool(result[0]), str(result[1]), float(result[2])
+                if len(result) == 2:
+                    passed, message = result
+                    return bool(passed), str(message), confidence
+                if len(result) == 1:
+                    result = result[0]
+
+            if isinstance(result, bool):
+                if result:
+                    message = failure_message or "Custom rule passed"
+                else:
+                    message = failure_message or "Custom rule failed"
+                return result, message, confidence
+
+            raise ValueError("Verification rule must return bool or tuple")
+
+        self.verification_rules[extraction_class].append(wrapped)
     
     def verify_extraction(
         self,
@@ -300,7 +433,7 @@ class ExtractionVerifier:
         try:
             from dateutil import parser
             date = parser.parse(extraction.extraction_text)
-            
+
             current_year = datetime.now().year
             if date.year < 1900:
                 return False, f"Date year {date.year} is before 1900", 0.2
@@ -308,8 +441,8 @@ class ExtractionVerifier:
                 return False, f"Date year {date.year} is more than 10 years in future", 0.3
             else:
                 return True, "Date is in reasonable range", 0.9
-        except:
-            return False, "Could not parse date", 0.1
+        except Exception:
+            return False, "Invalid date value", 0.1
     
     def _verify_date_format(self, extraction: data.Extraction, external_data: Optional[Dict]) -> Tuple[bool, str, float]:
         """Verify date format is valid."""
@@ -320,12 +453,13 @@ class ExtractionVerifier:
             r'^\d{1,2}[/-]\d{1,2}[/-]\d{2,4}$',
             r'^\d{4}[/-]\d{1,2}[/-]\d{1,2}$',
             r'^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*\s+\d{1,2},?\s+\d{4}$',
+            r'^\d{1,2}\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*\s+\d{4}$',
         ]
         
         if any(re.match(p, text) for p in patterns):
             return True, "Valid date format", 0.95
         else:
-            return False, "Unusual date format", 0.4
+            return False, "Invalid or unusual date format", 0.4
     
     def _verify_amount_range(self, extraction: data.Extraction, external_data: Optional[Dict]) -> Tuple[bool, str, float]:
         """Verify amount is in reasonable range."""
@@ -353,7 +487,7 @@ class ExtractionVerifier:
         elif re.match(r'^[\d,]+\.?\d*$', text):
             return True, "Valid numeric format", 0.8
         else:
-            return False, "Unusual amount format", 0.4
+            return False, "Invalid amount format", 0.4
     
     def _verify_email_format(self, extraction: data.Extraction, external_data: Optional[Dict]) -> Tuple[bool, str, float]:
         """Verify email format is valid."""
@@ -369,18 +503,16 @@ class ExtractionVerifier:
 class ExtractionAnnotator:
     """Main annotator class that combines quality scoring and verification."""
     
-    def __init__(self, author: Optional[str] = None):
-        """
-        Initialize the annotator.
-        
-        Args:
-            author: Optional author name for annotations
-        """
+    def __init__(self, author: Optional[str] = None, include_timestamps: bool = True):
+        """Initialize the annotator."""
+
         self.author = author or "system"
+        self.include_timestamps = include_timestamps
         self.quality_scorer = QualityScorer()
         self.verifier = ExtractionVerifier()
         self.annotations: List[Annotation] = []
         self._annotation_counter = 0
+        self._fallback_ids: Dict[int, str] = {}
     
     def annotate_extraction(
         self,
@@ -401,21 +533,39 @@ class ExtractionAnnotator:
         Returns:
             List of annotations added
         """
-        annotations = []
-        
-        # Add quality annotation
+        annotations: List[Annotation] = []
+
         quality_ann = self.annotate_quality(extraction, text, all_extractions)
         annotations.append(quality_ann)
-        
-        # Add verification annotation
-        verify_ann = self.annotate_verification(extraction, external_data)
-        annotations.append(verify_ann)
-        
-        # Add warnings if needed
-        warning_anns = self.annotate_warnings(extraction)
-        annotations.extend(warning_anns)
-        
+
+        verification_ann = self.annotate_verification(extraction, external_data)
+        annotations.append(verification_ann)
+
+        warning_annotations = self.annotate_warnings(extraction, verification_ann)
+        annotations.extend(warning_annotations)
+
         return annotations
+
+    def annotate_document(
+        self,
+        document: data.AnnotatedDocument,
+        external_data: Optional[Dict[str, Any]] = None,
+    ) -> data.AnnotatedDocument:
+        """Annotate all extractions in a document."""
+
+        text = getattr(document, "text", "")
+        extractions = list(getattr(document, "extractions", []) or [])
+
+        for extraction in extractions:
+            self.annotate_extraction(
+                extraction,
+                text,
+                all_extractions=extractions,
+                external_data=external_data,
+            )
+
+        document.annotations = self.export_annotations()
+        return document
     
     def annotate_quality(
         self,
@@ -424,32 +574,30 @@ class ExtractionAnnotator:
         all_extractions: Optional[List[data.Extraction]] = None
     ) -> Annotation:
         """Add quality annotation to an extraction."""
-        score = self.quality_scorer.score_extraction(extraction, text, all_extractions)
-        
-        # Determine quality level
-        if score >= ConfidenceLevel.VERY_HIGH.value:
-            quality_level = "Very High"
-        elif score >= ConfidenceLevel.HIGH.value:
-            quality_level = "High"
-        elif score >= ConfidenceLevel.MEDIUM.value:
-            quality_level = "Medium"
-        elif score >= ConfidenceLevel.LOW.value:
-            quality_level = "Low"
-        else:
-            quality_level = "Very Low"
-        
-        annotation = Annotation(
-            annotation_id=self._get_next_id(),
-            extraction_id=extraction.extraction_id or "",
-            annotation_type=AnnotationType.QUALITY,
-            content=f"Quality: {quality_level} (score: {score:.2f})",
-            confidence=score,
-            timestamp=datetime.now(),
-            author=self.author,
-            metadata={'quality_score': score, 'quality_level': quality_level}
+        factor_scores = self.quality_scorer._compute_factor_scores(
+            extraction, text, all_extractions
         )
-        
-        self.annotations.append(annotation)
+        aggregate_score = self.quality_scorer._aggregate_factor_scores(factor_scores)
+        score = self.quality_scorer._apply_penalties(extraction, text, aggregate_score)
+        score = min(max(score, 0.0), 1.0)
+        quality_level = self._score_to_confidence_level(score)
+
+        annotation = self._create_annotation(
+            annotation_type=AnnotationType.QUALITY_SCORE,
+            extraction=extraction,
+            extraction_id=getattr(extraction, "extraction_id", None),
+            content={
+                "score": round(score, 3),
+                "level": quality_level.value,
+                "factors": factor_scores,
+            },
+            confidence=quality_level,
+            metadata={
+                "quality_score": score,
+                "quality_level": quality_level.value,
+            },
+        )
+
         return annotation
     
     def annotate_verification(
@@ -459,70 +607,92 @@ class ExtractionAnnotator:
     ) -> Annotation:
         """Add verification annotation to an extraction."""
         is_valid, message, confidence = self.verifier.verify_extraction(extraction, external_data)
-        
-        annotation = Annotation(
-            annotation_id=self._get_next_id(),
-            extraction_id=extraction.extraction_id or "",
+
+        annotation = self._create_annotation(
             annotation_type=AnnotationType.VERIFICATION,
-            content=f"Verification: {'PASSED' if is_valid else 'FAILED'} - {message}",
+            extraction=extraction,
+            extraction_id=getattr(extraction, "extraction_id", None),
+            content={
+                "status": "passed" if is_valid else "failed",
+                "message": message,
+            },
             confidence=confidence,
-            timestamp=datetime.now(),
-            author=self.author,
-            metadata={'is_valid': is_valid, 'verification_message': message}
+            metadata={
+                "is_valid": is_valid,
+                "verification_message": message,
+                "used_external_data": bool(external_data),
+            },
         )
-        
-        self.annotations.append(annotation)
+
         return annotation
     
-    def annotate_warnings(self, extraction: data.Extraction) -> List[Annotation]:
+    def annotate_warnings(
+        self,
+        extraction: data.Extraction,
+        verification: Optional[Annotation] = None,
+    ) -> List[Annotation]:
         """Add warning annotations for potential issues."""
-        warnings = []
-        
-        # Check for suspicious patterns
-        text = extraction.extraction_text
-        
-        # Very long extraction
-        if len(text) > 500:
-            warning = Annotation(
-                annotation_id=self._get_next_id(),
-                extraction_id=extraction.extraction_id or "",
-                annotation_type=AnnotationType.WARNING,
-                content=f"Very long extraction ({len(text)} characters)",
-                confidence=0.7,
-                timestamp=datetime.now(),
-                author=self.author
+
+        warnings: List[Annotation] = []
+        text_value = extraction.extraction_text or ""
+        extraction_id = getattr(extraction, "extraction_id", None)
+
+        if verification and verification.metadata.get("is_valid") is False:
+            warnings.append(
+                self._create_annotation(
+                    annotation_type=AnnotationType.WARNING,
+                    extraction=extraction,
+                    extraction_id=extraction_id,
+                    content={
+                        "issue": "invalid_extraction",
+                        "details": verification.metadata.get("verification_message"),
+                    },
+                    confidence=ConfidenceLevel.LOW,
+                )
             )
-            warnings.append(warning)
-            self.annotations.append(warning)
-        
-        # Contains markup
-        if any(char in text for char in ['<', '>', '{', '}', '[', ']']):
-            warning = Annotation(
-                annotation_id=self._get_next_id(),
-                extraction_id=extraction.extraction_id or "",
-                annotation_type=AnnotationType.WARNING,
-                content="Contains markup or special characters",
-                confidence=0.6,
-                timestamp=datetime.now(),
-                author=self.author
+
+        if len(text_value) > 500:
+            warnings.append(
+                self._create_annotation(
+                    annotation_type=AnnotationType.WARNING,
+                    extraction=extraction,
+                    extraction_id=extraction_id,
+                    content={
+                        "issue": "extraction_too_long",
+                        "details": f"Extraction length is {len(text_value)} characters",
+                    },
+                    confidence=ConfidenceLevel.LOW,
+                )
             )
-            warnings.append(warning)
-            self.annotations.append(warning)
-        
-        # No char interval (no grounding)
-        if not extraction.char_interval:
-            warning = Annotation(
-                annotation_id=self._get_next_id(),
-                extraction_id=extraction.extraction_id or "",
-                annotation_type=AnnotationType.WARNING,
-                content="No character position grounding",
-                confidence=0.5,
-                timestamp=datetime.now(),
-                author=self.author
+
+        if any(char in text_value for char in ['<', '>', '{', '}', '[', ']']):
+            warnings.append(
+                self._create_annotation(
+                    annotation_type=AnnotationType.WARNING,
+                    extraction=extraction,
+                    extraction_id=extraction_id,
+                    content={
+                        "issue": "contains_markup",
+                        "details": "Contains markup or special characters",
+                    },
+                    confidence=ConfidenceLevel.MEDIUM,
+                )
             )
-            warnings.append(warning)
-            self.annotations.append(warning)
-        
+
+        if not getattr(extraction, "char_interval", None):
+            warnings.append(
+                self._create_annotation(
+                    annotation_type=AnnotationType.WARNING,
+                    extraction=extraction,
+                    extraction_id=extraction_id,
+                    content={
+                        "issue": "missing_grounding",
+                        "details": "No character position grounding",
+                    },
+                    confidence=ConfidenceLevel.UNCERTAIN,
+                )
+            )
+
         return warnings
     
     def annotate_relationships(
@@ -531,25 +701,25 @@ class ExtractionAnnotator:
     ) -> List[Annotation]:
         """Add annotations for discovered relationships."""
         annotations = []
-        
+
         for rel in relationships:
-            annotation = Annotation(
-                annotation_id=self._get_next_id(),
-                extraction_id=rel.entity1_id,
-                annotation_type=AnnotationType.RELATIONSHIP,
-                content=f"Related to {rel.entity2_id} via {rel.relationship_type}",
-                confidence=rel.confidence,
-                timestamp=datetime.now(),
-                author=self.author,
-                metadata={
-                    'related_entity': rel.entity2_id,
-                    'relationship': rel.relationship_type,
-                    'evidence': rel.evidence
-                }
+            annotations.append(
+                self._create_annotation(
+                    annotation_type=AnnotationType.RELATIONSHIP,
+                    extraction_id=getattr(rel, "entity1_id", None),
+                    content={
+                        "related_entity": getattr(rel, "entity2_id", None),
+                        "relationship": getattr(rel, "relationship_type", None),
+                    },
+                    confidence=getattr(rel, "confidence", None),
+                    metadata={
+                        "related_entity": getattr(rel, "entity2_id", None),
+                        "relationship": getattr(rel, "relationship_type", None),
+                        "evidence": getattr(rel, "evidence", None),
+                    },
+                )
             )
-            annotations.append(annotation)
-            self.annotations.append(annotation)
-        
+
         return annotations
     
     def get_annotations_for_extraction(self, extraction_id: str) -> List[Annotation]:
@@ -558,13 +728,65 @@ class ExtractionAnnotator:
     
     def export_annotations(self) -> Dict[str, List[Dict[str, Any]]]:
         """Export all annotations grouped by extraction ID."""
-        grouped = {}
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
         for ann in self.annotations:
-            if ann.extraction_id not in grouped:
-                grouped[ann.extraction_id] = []
-            grouped[ann.extraction_id].append(ann.to_dict())
+            key = ann.extraction_id or ""
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(ann.to_dict())
         return grouped
-    
+
+    def _score_to_confidence_level(self, score: float) -> ConfidenceLevel:
+        if score >= 0.9:
+            return ConfidenceLevel.VERY_HIGH
+        if score >= 0.75:
+            return ConfidenceLevel.HIGH
+        if score >= 0.5:
+            return ConfidenceLevel.MEDIUM
+        if score >= 0.3:
+            return ConfidenceLevel.LOW
+        return ConfidenceLevel.VERY_LOW
+
+    def _create_annotation(
+        self,
+        *,
+        annotation_type: AnnotationType,
+        content: Union[Dict[str, Any], List[Any], str],
+        extraction: Optional[data.Extraction] = None,
+        extraction_id: Optional[str] = None,
+        confidence: Optional[Union[float, ConfidenceLevel]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Annotation:
+        resolved_id = extraction_id
+
+        if resolved_id is None and extraction is not None:
+            resolved_id = getattr(extraction, "extraction_id", None)
+
+        if (resolved_id is None or resolved_id == "") and extraction is not None:
+            resolved_id = self._fallback_ids.get(id(extraction))
+            if resolved_id is None:
+                resolved_id = f"extraction_{len(self._fallback_ids) + 1:04d}"
+                self._fallback_ids[id(extraction)] = resolved_id
+
+        if resolved_id is None:
+            resolved_id = ""
+
+        if resolved_id != "":
+            resolved_id = str(resolved_id)
+
+        annotation = Annotation(
+            annotation_id=self._get_next_id(),
+            extraction_id=resolved_id,
+            annotation_type=annotation_type,
+            content=content,
+            confidence=confidence,
+            timestamp=datetime.now() if self.include_timestamps else None,
+            author=self.author,
+            metadata=metadata or {},
+        )
+        self.annotations.append(annotation)
+        return annotation
+
     def _get_next_id(self) -> str:
         """Get the next annotation ID."""
         self._annotation_counter += 1


### PR DESCRIPTION
## Summary
- update annotation enums and dataclass to support structured content and richer confidence handling
- enhance quality scoring, verifier helpers, and annotator flows with batch scoring, fallback IDs, and timestamp controls
- expand annotation tests to cover the revised API surface, batch behavior, and timestamp settings

## Testing
- pytest tests/test_annotation.py

------
https://chatgpt.com/codex/tasks/task_e_68d16cb3ef8083218b56547b99a74b18